### PR TITLE
fix: add non-zero exit code for CI/CD integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,28 +1,62 @@
-# secret_scanner.py
+# secret_scanner
 
-A simple Python tool that scans all files in a folder for potentially sensitive content such as AWS access keys, passwords, or secrets. Alerts are printed as they’re found, followed by a summary report.
+A Python tool that scans directories for sensitive content such as AWS access keys, passwords, and secrets. Designed for use in CI/CD pipelines and GRC engineering workflows.
+
+Maps to NIST 800-53 Rev 5 controls: **IA-5(7)**, **SC-12**, **SC-28**.
+Maps to CJIS v6.0 controls: **SC-12**, **SC-13**, **SC-28**.
 
 ## Features
-- Scans every file in a target directory  
+
+- Recursively scans all files in a target directory and its subdirectories
 - Detects:
-  - AWS key pattern (`AKIA`)
+  - AWS key patterns (`AKIA`)
   - `"password"` (case-insensitive)
   - `"secret"` (case-insensitive)
-- Counts total alerts
-- Tracks which files had issues (via a `set`)
-- Prints a clean summary at the end
+- Gracefully skips binary files and permission-denied files
+- Reports findings with relative paths for easy identification
+- Returns a non-zero exit code when secrets are found (CI/CD integration)
+- Supports `--exit-zero` for informational-only runs
+- Prints a summary with total alerts, affected files, directories scanned, and skipped files
 
 ## Usage
-1. `git clone` this repository
-2. Place files inside the `test_configs` directory (there are test config files currently)
-3. Run the script:
 
-```
+Scan the default `test_configs/` directory:
+
+```bash
 python secret_scanner.py
 ```
 
-## Requirements 
-- Python 3.x
+Scan a specific directory:
+
+```bash
+python secret_scanner.py /path/to/configs
+```
+
+Run in informational mode (always exit 0, even if secrets are found):
+
+```bash
+python secret_scanner.py /path/to/configs --exit-zero
+```
+
+View all options:
+
+```bash
+python secret_scanner.py --help
+```
+
+## Exit Codes
+
+| Code | Meaning |
+|------|---------|
+| `0`  | No secrets found, or `--exit-zero` was used |
+| `1`  | Secrets detected (default behavior) |
+
+In a CI/CD pipeline, the non-zero exit code will cause the step to fail, blocking merges that contain exposed secrets.
+
+## Requirements
+
+- Python 3.x (no third-party dependencies)
 
 ## License
-- MIT License 
+
+MIT License


### PR DESCRIPTION
## Summary
- Replaced manual `sys.argv` parsing with `argparse` for CLI argument handling
- Added `--exit-zero` flag for informational/audit-only runs
- Scanner now exits 1 when secrets are found (exits 0 when clean or `--exit-zero` is set)
- Updated README to reflect current features after all Sprint 1 fixes

## Controls Addressed
- SA-11: Scanner now enforces policy by failing the pipeline
- CM-3: Non-zero exit code blocks merges when secrets are detected

## Test Plan
- [x] Verified exit code 1 when secrets are found (default mode)
- [x] Verified exit code 0 when `--exit-zero` flag is used with findings
- [x] Verified exit code 0 on a clean directory with no findings
- [x] Verified `--help` output is generated automatically by argparse

Closes #4