### PR TITLE
chore: add .gitignore and prevent test data from leaking real secrets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,44 @@
+# Byte-compiled / optimized / DLL files
+# Python generates these automatically when importing modules.
+# They're machine-specific and should never be committed.
+__pycache__/
+*.py[cod]
+*$py.class
+
+# Virtual environments
+# These directories contain installed packages — often hundreds of files
+# that are already declared in requirements.txt or pyproject.toml.
+venv/
+.venv/
+env/
+
+# Environment and secret files
+# These are the exact files our scanner is designed to detect.
+# Ignoring them here prevents real credentials from being committed.
+*.env
+*.secrets
+.env.*
+
+# Distribution / packaging
+build/
+dist/
+*.egg-info/
+*.egg
+
+# IDE and editor files
+.vscode/
+.idea/
+*.swp
+*.swo
+*~
+
+# OS-generated files
+.DS_Store
+Thumbs.db
+
+# pytest cache
+.pytest_cache/
+
+# Coverage reports
+htmlcov/
+.coverage

--- a/README.md
+++ b/README.md
@@ -53,6 +53,12 @@ python secret_scanner.py --help
 
 In a CI/CD pipeline, the non-zero exit code will cause the step to fail, blocking merges that contain exposed secrets.
 
+## Test Data
+
+The `test_configs/` directory contains **intentionally fake credentials** for testing the scanner. All values use the AWS example key format (`AKIAIOSFODNN7EXAMPLE`) or clearly fake strings.
+
+**Never place real credentials in test files.** If you need to test against real-world patterns, use a `.env` or `.secrets` file — both are excluded from version control by `.gitignore`.
+
 ## Requirements
 
 - Python 3.x (no third-party dependencies)

--- a/test_configs/bad-config.json
+++ b/test_configs/bad-config.json
@@ -1,4 +1,5 @@
 {
+    "_comment": "TEST DATA ONLY — all credentials in this file are fake. Never use real secrets in test files.",
     "app_name": "my-grc-app",
     "aws_access_key": "AKIAIOSFODNN7EXAMPLE",
     "database_password": "SuperSecret123!"

--- a/test_configs/clean-config.json
+++ b/test_configs/clean-config.json
@@ -1,4 +1,5 @@
 {
+    "_comment": "TEST DATA ONLY — this file contains no secrets and should produce zero alerts.",
     "app_name": "my-grc-app",
     "region": "us-west-1",
     "log_level": "info"

--- a/test_configs/nested/deep-secret.json
+++ b/test_configs/nested/deep-secret.json
@@ -1,4 +1,5 @@
 {
+  "_comment": "TEST DATA ONLY — all credentials in this file are fake. Never use real secrets in test files.",
   "app_name": "nested-service",
   "database": {
     "host": "db.internal.example.com",

--- a/test_configs/terraform.tf
+++ b/test_configs/terraform.tf
@@ -1,3 +1,5 @@
+# TEST DATA ONLY — all credentials in this file are fake.
+# Never use real secrets in test files.
 provider "aws" {
   region     = "us-west-1"
   access_key = "AKIAIOSFODNN7EXAMPLE"


### PR DESCRIPTION
## Summary
- Added `.gitignore` with Python defaults, virtual env dirs, and `*.env`/`*.secrets` patterns
- Added header comments to all test data files marking credentials as intentionally fake
- Added "Test Data" section to README warning against using real credentials

## Controls Addressed
- CM-7: Repo only tracks necessary source files, not generated artifacts
- SC-28: `.gitignore` prevents real secrets from being committed to version control

## Test Plan
- [x] Ran `python secret_scanner.py` — scanner still detects all 8 alerts across 4 files
- [x] Verified `.gitignore` patterns cover `.env`, `.secrets`, `__pycache__`, and virtual env directories

Closes #10