### PR TITLE
feat: add CJIS CJI-pattern detection (ORI, NCIC, FBI, SID)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Secret Scanner
 
-A Python tool that scans directories for sensitive content such as AWS access keys, passwords, and secrets. Designed for use in CI/CD pipelines and GRC engineering workflows.
+A Python tool that scans directories for sensitive content using compiled regex patterns. Detects AWS credentials, API keys, passwords, private keys, JWTs, connection strings, and CJIS Criminal Justice Information (CJI) leakage. Designed for use in CI/CD pipelines and GRC engineering workflows targeting public safety technology environments.
 
 Maps to NIST 800-53 Rev 5 controls: **IA-5(7)**, **SC-12**, **SC-28**.
 Maps to CJIS v6.0 controls: **SC-12**, **SC-13**, **SC-28**.
@@ -8,15 +8,40 @@ Maps to CJIS v6.0 controls: **SC-12**, **SC-13**, **SC-28**.
 ## Features
 
 - Recursively scans all files in a target directory and its subdirectories
-- Detects:
-  - AWS key patterns (`AKIA`)
-  - `"password"` (case-insensitive)
-  - `"secret"` (case-insensitive)
+- Reports findings with file path and line number (e.g., `config.json:12`)
+- Detects secrets using compiled regex patterns that require assignment context to reduce false positives
+- Supports custom pattern files via `--patterns` for organization-specific detection rules
 - Gracefully skips binary files and permission-denied files
-- Reports findings with relative paths for easy identification
 - Returns a non-zero exit code when secrets are found (CI/CD integration)
 - Supports `--exit-zero` for informational-only runs
 - Prints a summary with total alerts, affected files, directories scanned, and skipped files
+
+## Detection Patterns
+
+### Secrets and Credentials
+
+| Pattern | Example Match |
+|---------|--------------|
+| AWS Access Key ID | `AKIAIOSFODNN7EXAMPLE` |
+| AWS Secret Access Key | `aws_secret_access_key = "wJalr..."` |
+| AWS Session Token | `aws_session_token = "FwoGZX..."` |
+| Password Assignment | `password = "hunter2"` |
+| Secret Assignment | `secret_key = "abc123"` |
+| API Key | `api_key = "sk-live-..."` |
+| Private Key Header | `-----BEGIN RSA PRIVATE KEY-----` |
+| JWT Token | `eyJhbGciOiJIUzI1NiIs...` |
+| Connection String | `postgresql://admin:pass@host:5432/db` |
+
+### CJIS Criminal Justice Information (CJI)
+
+| Pattern | What It Detects | Example Match |
+|---------|----------------|--------------|
+| CJI: ORI Number | Originating Agency Identifiers | `ori = "CA0380000"` |
+| CJI: NCIC Query Code | NCIC message format indicators | `NCIC QH hot file query` |
+| CJI: FBI Number | FBI Universal Control Numbers | `fbi_number = "123456AA7"` |
+| CJI: State ID (SID) | State criminal history record IDs | `sid = "CA12345678"` |
+
+CJI patterns address CJIS Security Policy v6.0 requirements: CJI must never appear in plaintext outside of authorized, encrypted systems. Detecting CJI leakage in config files and source code identifies violations of SC-28 (Protection of Information at Rest) and SC-13 (Cryptographic Protection).
 
 ## Usage
 
@@ -38,6 +63,23 @@ Run in informational mode (always exit 0, even if secrets are found):
 python secret_scanner.py /path/to/configs --exit-zero
 ```
 
+Load additional detection patterns from a JSON file:
+
+```bash
+python secret_scanner.py /path/to/configs --patterns custom_patterns.json
+```
+
+The patterns file should be a flat JSON object of `{"pattern_name": "regex_string"}`:
+
+```json
+{
+    "Slack Token": "xox[baprs]-[0-9a-zA-Z-]{10,}",
+    "GitHub PAT": "ghp_[A-Za-z0-9]{36}"
+}
+```
+
+Custom patterns are merged with the built-in defaults. If a custom pattern has the same name as a built-in, it overrides the built-in.
+
 View all options:
 
 ```bash
@@ -55,7 +97,7 @@ In a CI/CD pipeline, the non-zero exit code will cause the step to fail, blockin
 
 ## Test Data
 
-The `test_configs/` directory contains **intentionally fake credentials** for testing the scanner. All values use the AWS example key format (`AKIAIOSFODNN7EXAMPLE`) or clearly fake strings.
+The `test_configs/` directory contains **intentionally fake credentials and CJI identifiers** for testing the scanner. All values use the AWS example key format (`AKIAIOSFODNN7EXAMPLE`), clearly fake strings, or fabricated CJI data (fake ORI numbers, FBI numbers, etc.).
 
 **Never place real credentials in test files.** If you need to test against real-world patterns, use a `.env` or `.secrets` file — both are excluded from version control by `.gitignore`.
 

--- a/secret_scanner.py
+++ b/secret_scanner.py
@@ -7,6 +7,7 @@ This script scans a directory for sensitive information such as:
 - Database credentials and connection strings
 - Private key files (PEM headers)
 - JWT tokens
+- CJIS Criminal Justice Information (ORI numbers, NCIC codes, FBI numbers, SIDs)
 
 Detection uses compiled regex patterns instead of simple substring matching.
 This reduces false positives (a comment mentioning 'password' won't trigger)
@@ -99,6 +100,60 @@ def load_default_patterns():
         # The pattern requires scheme://user:password@host format.
         "Connection String": re.compile(
             r"[\w+]+://[^/\s:]+:[^/\s@]+@[^/\s]+"
+        ),
+
+        # === CJI (Criminal Justice Information) Patterns ===
+        # CJIS Security Policy v6.0 requires that CJI — including ORI numbers,
+        # NCIC codes, FBI numbers, and State IDs — never appear in plaintext
+        # outside of authorized, encrypted systems. Detecting CJI leakage in
+        # config files and source code addresses:
+        #   - SC-28 (Protection of Information at Rest): CJI must be encrypted
+        #   - SC-13 (Cryptographic Protection): FIPS 140-2/3 validated crypto
+        # A CJI leak in a config file is an immediate CJIS audit finding.
+
+        # ORI (Originating Agency Identifier): assigned by the FBI to every
+        # law enforcement agency. Format is two-letter state code + 7 digits
+        # (e.g., CA0380000 = LAPD, TX0140000 = Houston PD). We require an
+        # assignment context (ori, agency_id, originating_agency, etc.) to
+        # avoid false positives on random alphanumeric strings. The state
+        # codes are validated against US state/territory FIPS codes.
+        "CJI: ORI Number": re.compile(
+            r"(?i)(ori|agency_id|originating.agency)[\"']?\s*[=:]\s*[\"']?"
+            r"(?:A[LKSZR]|C[AOT]|D[EC]|F[LM]|G[AU]|HI|I[ADLN]|K[SY]|LA|"
+            r"M[ADEHINOPST]|N[CDEHJMVY]|O[HKR]|P[ARW]|RI|S[CD]|T[NX]|UT|"
+            r"V[AIT]|W[AIVY]|DC|AS|GU|MP|PR|VI)"
+            r"\d{7}"
+        ),
+
+        # NCIC (National Crime Information Center) message format indicators.
+        # NCIC queries use two-letter prefixes: QH (hot file query), QW (wanted
+        # persons), QR (vehicle registration), QV (stolen vehicle), QI (III/
+        # Interstate Identification Index). These are extremely sensitive — an
+        # NCIC query in a log or config file means CJI is being processed.
+        # We require the "NCIC" keyword nearby to avoid false positives on
+        # common two-letter combos. The pattern matches lines that contain
+        # both "NCIC" and a query code in assignment or message context.
+        "CJI: NCIC Query Code": re.compile(
+            r"(?i)ncic[^a-z\n]{0,30}(Q[HWRVIGM]|[AM]H|IC|EW)\b"
+        ),
+
+        # FBI Number (Universal Control Number): assigned to individuals in
+        # the III (Interstate Identification Index). Common format is a series
+        # of digits, optionally with a letter suffix, assigned after a
+        # fingerprint-based background check. We require the keyword "fbi_number",
+        # "ucn", or "fbi_id" in assignment context to avoid matching arbitrary
+        # numbers. Example: fbi_number = "123456AA7"
+        "CJI: FBI Number": re.compile(
+            r"(?i)(fbi.number|fbi.id|ucn)[\"']?\s*[=:]\s*[\"']?\d{5,10}[A-Z]{0,2}\d?"
+        ),
+
+        # State ID / SID (State Identification Number): assigned by state
+        # criminal history repositories. Format varies by state but typically
+        # follows a keyword like "sid", "state_id", or "sid_number" plus a
+        # numeric or alphanumeric value. CJI because it links to criminal
+        # history records (CHRI), which are among the most sensitive CJI types.
+        "CJI: State ID (SID)": re.compile(
+            r"(?i)(sid|state.id|sid.number)[\"']?\s*[=:]\s*[\"']?[A-Z0-9]{4,15}"
         ),
     }
 

--- a/test_configs/cji-leak.json
+++ b/test_configs/cji-leak.json
@@ -1,0 +1,37 @@
+{
+    "_comment": "TEST DATA ONLY — all CJI identifiers in this file are fake.",
+    "_purpose": "Exercises CJI-pattern detection for CJIS v6.0 compliance scanning.",
+    "_controls": "SC-28 (CJI at rest), SC-13 (Cryptographic Protection)",
+
+    "agency_config": {
+        "ori": "CA0380000",
+        "agency_id": "TX0140000",
+        "originating_agency": "NY0300000",
+        "agency_name": "Fake County Sheriff's Office"
+    },
+
+    "ncic_config": {
+        "ncic_query_type": "NCIC QH hot file query",
+        "ncic_message_format": "NCIC QW wanted persons lookup",
+        "ncic_vehicle_check": "NCIC QR registration query"
+    },
+
+    "personnel_records": {
+        "fbi_number": "123456AA7",
+        "fbi_id": "9876543B2",
+        "ucn": "555123456"
+    },
+
+    "state_records": {
+        "sid": "CA12345678",
+        "state_id": "TX9876543",
+        "sid_number": "NY2468101"
+    },
+
+    "safe_fields_no_alert": {
+        "description": "This config mentions CJI but has no actual identifiers",
+        "log_level": "info",
+        "region": "us-west-2",
+        "note": "Ensure CJIS compliance before deploying"
+    }
+}


### PR DESCRIPTION
## Summary
- Added 4 CJI-specific regex patterns: ORI numbers, NCIC query codes, FBI numbers, State IDs
- ORI pattern validates against US state/territory FIPS codes to reduce false positives
- All CJI patterns prefixed with 'CJI:' for separate categorization in output
- Created `test_configs/cji-leak.json` with fake CJI data covering all new patterns
- Updated README to reflect current scanner capabilities (regex patterns, line numbers, `--patterns` flag, CJI detection)

## Controls Addressed
- CJIS v6.0 SC-28: CJI at rest must be encrypted or otherwise protected
- CJIS v6.0 SC-13: Cryptographic Protection for CJI
- NIST 800-53 SC-28: Protection of Information at Rest
- NIST 800-53 SC-12: Cryptographic Key Establishment and Management

## Test Plan
- [x] Ran scanner against `test_configs/` — all 12 CJI findings detected (3 per pattern type)
- [x] Safe fields in `cji-leak.json` produced no false positives
- [x] All existing patterns continue to detect correctly (14 existing alerts unchanged)

Closes #5