### PR TITLE
feat: add severity classification to findings

### DIFF
--- a/secret_scanner/__init__.py
+++ b/secret_scanner/__init__.py
@@ -21,4 +21,4 @@ Usage as library:
 # Scanner version — included in JSON output metadata so consumers can track
 # which version produced a given evidence artifact. Bump this when detection
 # capabilities change (new patterns, new output fields, etc.).
-__version__ = "0.7.0"
+__version__ = "0.8.0"

--- a/secret_scanner/output/console.py
+++ b/secret_scanner/output/console.py
@@ -7,20 +7,23 @@ know how results are displayed — it just returns data.
 """
 
 
-def print_alert(relative_path, line_number, pattern_name):
+def print_alert(relative_path, line_number, pattern_name, severity):
     """Print a single finding alert to the console.
 
-    Format: [ALERT] path/to/file:line_number — Pattern Name
+    Format: [SEVERITY] path/to/file:line_number — Pattern Name
 
-    The path:line_number format is deliberate — many editors and terminals
-    make this clickable, jumping directly to the finding location.
+    The severity level replaces the generic [ALERT] tag so analysts can
+    visually scan output for CRITICAL findings. The path:line_number
+    format is deliberate — many editors and terminals make this clickable,
+    jumping directly to the finding location.
 
     Args:
         relative_path: File path relative to the scan root.
         line_number: 1-indexed line number where the pattern matched.
         pattern_name: Human-readable name of the matched pattern.
+        severity: Severity level string (CRITICAL, HIGH, MEDIUM, LOW, INFO).
     """
-    print(f"[ALERT] {relative_path}:{line_number} — {pattern_name}")
+    print(f"[{severity}] {relative_path}:{line_number} — {pattern_name}")
 
 
 def print_skip(relative_path, reason):
@@ -36,6 +39,10 @@ def print_skip(relative_path, reason):
 def print_summary(scan_result):
     """Print the final scan summary to the console.
 
+    Includes a severity breakdown so analysts get an at-a-glance risk
+    picture. This supports RA-3 (Risk Assessment) by surfacing how many
+    findings fall into each severity tier.
+
     Args:
         scan_result: A dict containing scan results with keys:
             - directories_scanned: int
@@ -45,6 +52,7 @@ def print_summary(scan_result):
             - skipped_files: int
             - scan_duration: float (seconds)
             - affected_files: sorted list of relative path strings
+            - findings: list of finding dicts (each with "severity" key)
     """
     print("\n--- Scan Summary ---")
     print(f"Directories scanned: {scan_result['directories_scanned']}")
@@ -53,6 +61,22 @@ def print_summary(scan_result):
     print(f"Files with issues: {scan_result['files_with_findings']}")
     print(f"Skipped files: {scan_result['skipped_files']}")
     print(f"Scan duration: {scan_result['scan_duration']}s")
+
+    # Severity breakdown: count findings by severity level.
+    # Uses dict.get() with a default of 0 (PCC3e Ch 6: Dictionaries).
+    # The severity order is fixed (CRITICAL first) so the output is
+    # always consistent regardless of which severities appear.
+    if scan_result["findings"]:
+        severity_counts = {}
+        for finding in scan_result["findings"]:
+            sev = finding["severity"]
+            severity_counts[sev] = severity_counts.get(sev, 0) + 1
+
+        print("Severity breakdown:")
+        for level in ["CRITICAL", "HIGH", "MEDIUM", "LOW", "INFO"]:
+            count = severity_counts.get(level, 0)
+            if count > 0:
+                print(f"  {level}: {count}")
 
     if scan_result["affected_files"]:
         print("Affected files:")

--- a/secret_scanner/output/json_report.py
+++ b/secret_scanner/output/json_report.py
@@ -33,13 +33,17 @@ def write_json_report(scan_result, output_file, scanner_version, folder,
         folder: The scanned directory path (for metadata).
         patterns_active: Number of active patterns (for metadata).
     """
-    # Build findings_by_type: a dict of {pattern_name: count}.
-    # This uses a simple loop instead of collections.Counter — both work,
+    # Build findings_by_type and findings_by_severity: dicts of {key: count}.
+    # These use simple loops instead of collections.Counter — both work,
     # but the explicit loop is easier to follow when you're learning Python.
     findings_by_type = {}
+    findings_by_severity = {}
     for finding in scan_result["findings"]:
         finding_type = finding["finding_type"]
         findings_by_type[finding_type] = findings_by_type.get(finding_type, 0) + 1
+
+        severity = finding["severity"]
+        findings_by_severity[severity] = findings_by_severity.get(severity, 0) + 1
 
     # datetime.now(timezone.utc) returns the current time in UTC with timezone
     # info attached. .isoformat() formats it as ISO 8601 (e.g.,
@@ -60,6 +64,7 @@ def write_json_report(scan_result, output_file, scanner_version, folder,
             "files_with_findings": scan_result["files_with_findings"],
             "skipped_files": scan_result["skipped_files"],
             "findings_by_type": findings_by_type,
+            "findings_by_severity": findings_by_severity,
         },
     }
 

--- a/secret_scanner/patterns/__init__.py
+++ b/secret_scanner/patterns/__init__.py
@@ -38,6 +38,40 @@ CONTROL_MAP = {
 }
 
 
+# Severity levels for risk-based prioritization of findings.
+# Maps each pattern name to a severity string. This supports RA-3 (Risk
+# Assessment) by enabling analysts to triage findings based on impact:
+#
+#   CRITICAL — Immediate audit finding. Exposed cloud credentials or CJI
+#              in plaintext. Requires same-day remediation.
+#   HIGH     — Embedded credentials that enable unauthorized access.
+#              Connection strings and session tokens (JWTs) fall here.
+#   MEDIUM   — API keys where impact depends on what the key accesses.
+#              May be low-privilege or scoped, but still a finding.
+#   LOW      — Password/secret assignments. Often dev/test values, but
+#              still flagged because they indicate credential hygiene gaps.
+#   INFO     — Informational. Reserved for custom patterns or future use
+#              where context is needed but risk is minimal.
+#
+# Custom patterns without a SEVERITY_MAP entry default to "MEDIUM" — a
+# safe middle ground that ensures they're reviewed without over-alarming.
+SEVERITY_MAP = {
+    "AWS Access Key ID": "CRITICAL",
+    "AWS Secret Access Key": "CRITICAL",
+    "AWS Session Token": "CRITICAL",
+    "Private Key Header": "CRITICAL",
+    "CJI: ORI Number": "CRITICAL",
+    "CJI: NCIC Query Code": "CRITICAL",
+    "CJI: FBI Number": "CRITICAL",
+    "CJI: State ID (SID)": "CRITICAL",
+    "Connection String": "HIGH",
+    "JWT Token": "HIGH",
+    "API Key": "MEDIUM",
+    "Password Assignment": "LOW",
+    "Secret Assignment": "LOW",
+}
+
+
 def load_all_patterns():
     """Load and merge all built-in detection patterns.
 

--- a/secret_scanner/scanner.py
+++ b/secret_scanner/scanner.py
@@ -15,7 +15,7 @@ import time
 from pathlib import Path
 
 from .output.console import print_alert, print_skip
-from .patterns import CONTROL_MAP
+from .patterns import CONTROL_MAP, SEVERITY_MAP
 
 # Resource limits to prevent the scanner from consuming excessive memory
 # on unusually large files. Config files and source code are typically
@@ -122,7 +122,8 @@ def scan(directory, patterns):
 
                     for pattern_name, pattern_regex in patterns.items():
                         if pattern_regex.search(line):
-                            print_alert(relative_path, line_number, pattern_name)
+                            severity = SEVERITY_MAP.get(pattern_name, "MEDIUM")
+                            print_alert(relative_path, line_number, pattern_name, severity)
                             found_issue = True
 
                             findings.append({
@@ -130,7 +131,7 @@ def scan(directory, patterns):
                                 "line_number": line_number,
                                 "finding_type": pattern_name,
                                 "pattern_matched": pattern_regex.pattern,
-                                "severity": None,
+                                "severity": severity,
                                 "control_ids": CONTROL_MAP.get(pattern_name, []),
                             })
 


### PR DESCRIPTION
## Changes
- Add SEVERITY_MAP in patterns/__init__.py mapping each pattern to CRITICAL/HIGH/MEDIUM/LOW
- Console alerts now show severity level instead of generic [ALERT] tag
- Scan summary includes severity breakdown (CRITICAL: 18, HIGH: 2, MEDIUM: 3, LOW: 3)
- JSON output includes findings_by_severity in summary section
- Custom patterns without a mapping default to MEDIUM
- Bump version to 0.8.0

## Controls Addressed
- RA-3: Risk Assessment — severity classification supports risk-based prioritization
- RA-5: Vulnerability Monitoring and Scanning — structured severity enables triage workflows

## Testing
- Verified 26 findings across correct severity levels (18 CRITICAL, 2 HIGH, 3 MEDIUM, 3 LOW)
- Verified JSON output includes severity per finding and findings_by_severity summary
- Verified all existing functionality preserved (same file counts, same patterns)

Closes #12