### PR TITLE
test: add unit tests with pytest

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,20 @@
+# Makefile for secret_scanner
+#
+# Provides convenience targets for common tasks. Makefiles use tabs
+# for indentation (not spaces) — this is a Makefile syntax requirement.
+#
+# Usage:
+#   make test    — run the full test suite with pytest
+#   make scan    — run the scanner against test_configs/
+#   make scan-json — run the scanner and output JSON results
+
+.PHONY: test scan scan-json
+
+test:
+	python -m pytest tests/ -v
+
+scan:
+	python -m secret_scanner
+
+scan-json:
+	python -m secret_scanner --output json

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,144 @@
+"""Tests for CLI argument parsing and entry point behavior.
+
+Tests the argument parser and exit code logic. Uses pytest's capsys
+fixture for output capture and monkeypatch for overriding sys.argv.
+
+These tests verify that the CLI interface contract is maintained:
+correct exit codes, proper error messages, and flag behavior.
+"""
+
+from secret_scanner.cli import build_parser
+
+
+# --- Argument parser tests ---
+
+def test_parser_default_directory():
+    """Default directory should be test_configs when no arg provided."""
+    parser = build_parser()
+    args = parser.parse_args([])
+    assert args.directory == "test_configs"
+
+
+def test_parser_custom_directory():
+    """Custom directory should be parsed correctly."""
+    parser = build_parser()
+    args = parser.parse_args(["/some/path"])
+    assert args.directory == "/some/path"
+
+
+def test_parser_exit_zero_flag():
+    """--exit-zero should set exit_zero to True."""
+    parser = build_parser()
+    args = parser.parse_args(["--exit-zero"])
+    assert args.exit_zero is True
+
+
+def test_parser_exit_zero_default():
+    """exit_zero should default to False."""
+    parser = build_parser()
+    args = parser.parse_args([])
+    assert args.exit_zero is False
+
+
+def test_parser_output_json():
+    """--output json should be parsed correctly."""
+    parser = build_parser()
+    args = parser.parse_args(["--output", "json"])
+    assert args.output == "json"
+
+
+def test_parser_output_default():
+    """output should default to None."""
+    parser = build_parser()
+    args = parser.parse_args([])
+    assert args.output is None
+
+
+def test_parser_output_file():
+    """--output-file should override the default filename."""
+    parser = build_parser()
+    args = parser.parse_args(["--output-file", "custom.json"])
+    assert args.output_file == "custom.json"
+
+
+def test_parser_output_file_default():
+    """output_file should default to scan_results.json."""
+    parser = build_parser()
+    args = parser.parse_args([])
+    assert args.output_file == "scan_results.json"
+
+
+def test_parser_patterns_flag():
+    """--patterns should accept a file path."""
+    parser = build_parser()
+    args = parser.parse_args(["--patterns", "custom.json"])
+    assert args.patterns == "custom.json"
+
+
+def test_parser_all_flags_combined():
+    """All flags should work together without conflict."""
+    parser = build_parser()
+    args = parser.parse_args([
+        "/scan/dir",
+        "--exit-zero",
+        "--output", "json",
+        "--output-file", "out.json",
+        "--patterns", "extra.json",
+    ])
+    assert args.directory == "/scan/dir"
+    assert args.exit_zero is True
+    assert args.output == "json"
+    assert args.output_file == "out.json"
+    assert args.patterns == "extra.json"
+
+
+# --- Exit code tests (integration) ---
+
+def test_exit_code_1_on_findings(tmp_path):
+    """Scanner should exit 1 when findings exist."""
+    import subprocess
+    config = tmp_path / "secret.txt"
+    config.write_text("AKIAIOSFODNN7EXAMPLE")
+
+    result = subprocess.run(
+        ["python", "-m", "secret_scanner", str(tmp_path)],
+        capture_output=True, text=True,
+    )
+    assert result.returncode == 1
+
+
+def test_exit_code_0_on_clean(tmp_path):
+    """Scanner should exit 0 when no findings exist."""
+    import subprocess
+    config = tmp_path / "clean.txt"
+    config.write_text("nothing secret here")
+
+    result = subprocess.run(
+        ["python", "-m", "secret_scanner", str(tmp_path)],
+        capture_output=True, text=True,
+    )
+    assert result.returncode == 0
+
+
+def test_exit_zero_flag_overrides(tmp_path):
+    """--exit-zero should force exit 0 even with findings."""
+    import subprocess
+    config = tmp_path / "secret.txt"
+    config.write_text("AKIAIOSFODNN7EXAMPLE")
+
+    result = subprocess.run(
+        ["python", "-m", "secret_scanner", str(tmp_path), "--exit-zero"],
+        capture_output=True, text=True,
+    )
+    assert result.returncode == 0
+
+
+def test_exit_code_1_on_nonexistent_directory():
+    """Scanner should exit 1 for a nonexistent directory."""
+    import subprocess
+    result = subprocess.run(
+        ["python", "-m", "secret_scanner", "/nonexistent/dir"],
+        capture_output=True, text=True,
+    )
+    assert result.returncode == 1
+    assert "[ERROR]" in result.stderr or "[ERROR]" in result.stdout

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -1,0 +1,189 @@
+"""Tests for output formatters.
+
+Tests the console and JSON output modules to ensure they produce
+correct, well-structured output. Uses pytest's capsys fixture to
+capture stdout for console output tests, and tmp_path for JSON file
+output tests.
+
+capsys is a pytest built-in fixture that captures what your code
+prints to stdout and stderr. After calling your function, you use
+capsys.readouterr() to get the captured text — then assert on it.
+"""
+
+import json
+
+from secret_scanner.output.console import print_alert, print_skip, print_summary
+from secret_scanner.output.json_report import write_json_report
+
+
+# --- Console output tests ---
+
+def test_print_alert_format(capsys):
+    """Alert output should include severity, path, line number, and pattern."""
+    print_alert("config.json", 5, "AWS Access Key ID", "CRITICAL")
+    captured = capsys.readouterr()
+    assert "[CRITICAL]" in captured.out
+    assert "config.json:5" in captured.out
+    assert "AWS Access Key ID" in captured.out
+
+
+def test_print_alert_severity_levels(capsys):
+    """Each severity level should appear in the output tag."""
+    for severity in ["CRITICAL", "HIGH", "MEDIUM", "LOW", "INFO"]:
+        print_alert("test.txt", 1, "Test", severity)
+    captured = capsys.readouterr()
+    for severity in ["CRITICAL", "HIGH", "MEDIUM", "LOW", "INFO"]:
+        assert f"[{severity}]" in captured.out
+
+
+def test_print_skip_format(capsys):
+    """Skip output should include path and reason."""
+    print_skip("image.png", "The file type is not compatible.")
+    captured = capsys.readouterr()
+    assert "[SKIP]" in captured.out
+    assert "image.png" in captured.out
+    assert "not compatible" in captured.out
+
+
+def test_print_summary_content(capsys):
+    """Summary should include all key metrics."""
+    scan_result = {
+        "directories_scanned": 3,
+        "total_files_scanned": 10,
+        "total_findings": 5,
+        "files_with_findings": 2,
+        "skipped_files": 1,
+        "scan_duration": 0.042,
+        "affected_files": ["config.json", "secrets.env"],
+        "findings": [
+            {"severity": "CRITICAL"},
+            {"severity": "CRITICAL"},
+            {"severity": "HIGH"},
+            {"severity": "MEDIUM"},
+            {"severity": "LOW"},
+        ],
+    }
+    print_summary(scan_result)
+    captured = capsys.readouterr()
+
+    assert "Directories scanned: 3" in captured.out
+    assert "Files scanned: 10" in captured.out
+    assert "Total alerts: 5" in captured.out
+    assert "Files with issues: 2" in captured.out
+    assert "Skipped files: 1" in captured.out
+    assert "0.042s" in captured.out
+    assert "config.json" in captured.out
+    assert "secrets.env" in captured.out
+
+
+def test_print_summary_severity_breakdown(capsys):
+    """Summary should include severity counts."""
+    scan_result = {
+        "directories_scanned": 1,
+        "total_files_scanned": 1,
+        "total_findings": 3,
+        "files_with_findings": 1,
+        "skipped_files": 0,
+        "scan_duration": 0.001,
+        "affected_files": ["test.txt"],
+        "findings": [
+            {"severity": "CRITICAL"},
+            {"severity": "CRITICAL"},
+            {"severity": "LOW"},
+        ],
+    }
+    print_summary(scan_result)
+    captured = capsys.readouterr()
+
+    assert "CRITICAL: 2" in captured.out
+    assert "LOW: 1" in captured.out
+
+
+def test_print_summary_no_findings(capsys):
+    """Summary with zero findings should not print severity or affected files."""
+    scan_result = {
+        "directories_scanned": 1,
+        "total_files_scanned": 1,
+        "total_findings": 0,
+        "files_with_findings": 0,
+        "skipped_files": 0,
+        "scan_duration": 0.001,
+        "affected_files": [],
+        "findings": [],
+    }
+    print_summary(scan_result)
+    captured = capsys.readouterr()
+
+    assert "Total alerts: 0" in captured.out
+    assert "Severity breakdown" not in captured.out
+    assert "Affected files" not in captured.out
+
+
+# --- JSON output tests ---
+
+def test_json_report_structure(tmp_path):
+    """JSON report should contain metadata, findings, and summary sections."""
+    scan_result = {
+        "findings": [
+            {
+                "file_path": "config.json",
+                "line_number": 4,
+                "finding_type": "AWS Access Key ID",
+                "pattern_matched": "AKIA[0-9A-Z]{16}",
+                "severity": "CRITICAL",
+                "control_ids": ["IA-5(7)", "SC-12", "SC-28"],
+            }
+        ],
+        "total_files_scanned": 5,
+        "total_findings": 1,
+        "files_with_findings": 1,
+        "skipped_files": 0,
+        "scan_duration": 0.003,
+    }
+    output_file = tmp_path / "results.json"
+
+    write_json_report(scan_result, str(output_file), "0.8.0", "/scan/dir", 13)
+
+    data = json.loads(output_file.read_text())
+
+    # Top-level sections
+    assert "scan_metadata" in data
+    assert "findings" in data
+    assert "summary" in data
+
+    # Metadata fields
+    assert "timestamp" in data["scan_metadata"]
+    assert data["scan_metadata"]["scanner_version"] == "0.8.0"
+    assert data["scan_metadata"]["patterns_active"] == 13
+
+    # Finding fields
+    assert len(data["findings"]) == 1
+    assert data["findings"][0]["severity"] == "CRITICAL"
+    assert data["findings"][0]["control_ids"] == ["IA-5(7)", "SC-12", "SC-28"]
+
+    # Summary fields
+    assert data["summary"]["total_findings"] == 1
+    assert "findings_by_type" in data["summary"]
+    assert "findings_by_severity" in data["summary"]
+    assert data["summary"]["findings_by_severity"]["CRITICAL"] == 1
+
+
+def test_json_report_overwrites_with_warning(tmp_path, capsys):
+    """Overwriting an existing file should produce a warning."""
+    output_file = tmp_path / "results.json"
+    output_file.write_text("{}")  # Pre-existing file
+
+    scan_result = {
+        "findings": [],
+        "total_files_scanned": 0,
+        "total_findings": 0,
+        "files_with_findings": 0,
+        "skipped_files": 0,
+        "scan_duration": 0.001,
+    }
+
+    write_json_report(scan_result, str(output_file), "0.8.0", "/scan", 13)
+    captured = capsys.readouterr()
+
+    assert "[WARN]" in captured.out
+    assert "already exists" in captured.out

--- a/tests/test_patterns.py
+++ b/tests/test_patterns.py
@@ -1,0 +1,367 @@
+"""Tests for secret detection patterns.
+
+Each test verifies that a pattern matches known-positive strings and
+does NOT match known-negative strings (false positive prevention).
+This is the most critical test file — if a pattern regresses, secrets
+go undetected, which is an IA-5(7) gap.
+
+Uses pytest's plain assert statements (PCC3e Ch 11: Testing Your Code).
+No fixtures needed — patterns are pure functions that return compiled regex.
+"""
+
+from secret_scanner.patterns import load_all_patterns, CONTROL_MAP, SEVERITY_MAP
+from secret_scanner.patterns import aws, cji, generic
+from secret_scanner.patterns.custom import load as load_custom
+
+
+# --- Pattern loading tests ---
+
+def test_load_all_patterns_returns_13():
+    """All 13 built-in patterns should be loaded."""
+    patterns = load_all_patterns()
+    assert len(patterns) == 13
+
+
+def test_load_all_patterns_names():
+    """Verify all expected pattern names are present."""
+    patterns = load_all_patterns()
+    expected = {
+        "AWS Access Key ID", "AWS Secret Access Key", "AWS Session Token",
+        "Password Assignment", "Secret Assignment", "API Key",
+        "Private Key Header", "JWT Token", "Connection String",
+        "CJI: ORI Number", "CJI: NCIC Query Code",
+        "CJI: FBI Number", "CJI: State ID (SID)",
+    }
+    assert set(patterns.keys()) == expected
+
+
+def test_every_pattern_has_control_mapping():
+    """Every built-in pattern must have a CONTROL_MAP entry."""
+    patterns = load_all_patterns()
+    for name in patterns:
+        assert name in CONTROL_MAP, f"Missing CONTROL_MAP entry for '{name}'"
+
+
+def test_every_pattern_has_severity_mapping():
+    """Every built-in pattern must have a SEVERITY_MAP entry."""
+    patterns = load_all_patterns()
+    for name in patterns:
+        assert name in SEVERITY_MAP, f"Missing SEVERITY_MAP entry for '{name}'"
+
+
+def test_aws_loads_3_patterns():
+    """AWS module should provide exactly 3 patterns."""
+    assert len(aws.load()) == 3
+
+
+def test_cji_loads_4_patterns():
+    """CJI module should provide exactly 4 patterns."""
+    assert len(cji.load()) == 4
+
+
+def test_generic_loads_6_patterns():
+    """Generic module should provide exactly 6 patterns."""
+    assert len(generic.load()) == 6
+
+
+# --- AWS pattern matching tests ---
+
+class TestAWSAccessKeyID:
+    """Tests for the AWS Access Key ID pattern."""
+
+    def setup_method(self):
+        """Load patterns once for each test method."""
+        self.pattern = load_all_patterns()["AWS Access Key ID"]
+
+    def test_matches_valid_key(self):
+        assert self.pattern.search("AKIAIOSFODNN7EXAMPLE")
+
+    def test_matches_key_in_assignment(self):
+        assert self.pattern.search('aws_access_key_id = "AKIAIOSFODNN7EXAMPLE"')
+
+    def test_rejects_short_key(self):
+        """Key ID must be exactly AKIA + 16 chars."""
+        assert not self.pattern.search("AKIATOOSHORT")
+
+    def test_rejects_lowercase(self):
+        """AWS key IDs are uppercase only."""
+        assert not self.pattern.search("AKIAiosfodnn7example")
+
+    def test_rejects_no_akia_prefix(self):
+        assert not self.pattern.search("XKIAIOSFODNN7EXAMPLE")
+
+
+class TestAWSSecretAccessKey:
+    """Tests for the AWS Secret Access Key pattern."""
+
+    def setup_method(self):
+        self.pattern = load_all_patterns()["AWS Secret Access Key"]
+
+    def test_matches_with_equals(self):
+        assert self.pattern.search(
+            "aws_secret_access_key = wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
+        )
+
+    def test_matches_with_colon(self):
+        assert self.pattern.search(
+            'secret_key: "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"'
+        )
+
+    def test_matches_case_insensitive(self):
+        assert self.pattern.search(
+            "AWS_SECRET_ACCESS_KEY = wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
+        )
+
+    def test_rejects_short_value(self):
+        """Secret keys are 40 chars — shorter values shouldn't match."""
+        assert not self.pattern.search("aws_secret_access_key = tooshort")
+
+    def test_rejects_comment_mention(self):
+        """A comment about secret keys without assignment shouldn't match."""
+        assert not self.pattern.search("# The aws_secret_access_key goes here")
+
+
+class TestAWSSessionToken:
+    """Tests for the AWS Session Token pattern."""
+
+    def setup_method(self):
+        self.pattern = load_all_patterns()["AWS Session Token"]
+
+    def test_matches_token_assignment(self):
+        assert self.pattern.search(
+            "aws_session_token = FwoGZXIvYXdzEBYaDHqa0AP"
+        )
+
+    def test_rejects_no_assignment(self):
+        assert not self.pattern.search("aws_session_token is required")
+
+
+# --- Generic pattern matching tests ---
+
+class TestPasswordAssignment:
+    """Tests for the Password Assignment pattern."""
+
+    def setup_method(self):
+        self.pattern = load_all_patterns()["Password Assignment"]
+
+    def test_matches_password_equals(self):
+        assert self.pattern.search('password = "hunter2"')
+
+    def test_matches_passwd_colon(self):
+        assert self.pattern.search('passwd: "s3cret"')
+
+    def test_matches_pwd_equals(self):
+        assert self.pattern.search("pwd = mypassword123")
+
+    def test_matches_json_format(self):
+        assert self.pattern.search('"password": "hunter2"')
+
+    def test_rejects_bare_mention(self):
+        """A comment mentioning 'password' without assignment shouldn't match."""
+        assert not self.pattern.search("# never store passwords in plaintext")
+
+
+class TestSecretAssignment:
+    """Tests for the Secret Assignment pattern."""
+
+    def setup_method(self):
+        self.pattern = load_all_patterns()["Secret Assignment"]
+
+    def test_matches_secret_equals(self):
+        assert self.pattern.search('secret = "abc123"')
+
+    def test_matches_secret_key_colon(self):
+        assert self.pattern.search("secret_key: some_value")
+
+    def test_rejects_bare_mention(self):
+        assert not self.pattern.search("# this is a secret feature")
+
+
+class TestAPIKey:
+    """Tests for the API Key pattern."""
+
+    def setup_method(self):
+        self.pattern = load_all_patterns()["API Key"]
+
+    def test_matches_api_key_equals(self):
+        assert self.pattern.search('api_key = "sk-live-abc123"')
+
+    def test_matches_apikey_colon(self):
+        assert self.pattern.search("apikey: my-secret-key")
+
+    def test_matches_api_dash_key(self):
+        assert self.pattern.search("api-key = something")
+
+    def test_rejects_bare_mention(self):
+        assert not self.pattern.search("# get your api_key from the dashboard")
+
+
+class TestPrivateKeyHeader:
+    """Tests for the Private Key Header pattern."""
+
+    def setup_method(self):
+        self.pattern = load_all_patterns()["Private Key Header"]
+
+    def test_matches_rsa(self):
+        assert self.pattern.search("-----BEGIN RSA PRIVATE KEY-----")
+
+    def test_matches_generic(self):
+        assert self.pattern.search("-----BEGIN PRIVATE KEY-----")
+
+    def test_matches_ec(self):
+        assert self.pattern.search("-----BEGIN EC PRIVATE KEY-----")
+
+    def test_matches_openssh(self):
+        assert self.pattern.search("-----BEGIN OPENSSH PRIVATE KEY-----")
+
+    def test_rejects_public_key(self):
+        assert not self.pattern.search("-----BEGIN PUBLIC KEY-----")
+
+
+class TestJWTToken:
+    """Tests for the JWT Token pattern."""
+
+    def setup_method(self):
+        self.pattern = load_all_patterns()["JWT Token"]
+
+    def test_matches_valid_jwt(self):
+        assert self.pattern.search(
+            "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkw"
+        )
+
+    def test_rejects_short_segments(self):
+        """JWT segments must be at least 10 chars each."""
+        assert not self.pattern.search("eyJhbG.eyJz")
+
+
+class TestConnectionString:
+    """Tests for the Connection String pattern."""
+
+    def setup_method(self):
+        self.pattern = load_all_patterns()["Connection String"]
+
+    def test_matches_postgresql(self):
+        assert self.pattern.search(
+            "postgresql://admin:s3cret@db.example.com:5432/mydb"
+        )
+
+    def test_matches_mysql(self):
+        assert self.pattern.search("mysql://root:password@localhost/test")
+
+    def test_rejects_no_credentials(self):
+        """URLs without embedded credentials shouldn't match."""
+        assert not self.pattern.search("https://example.com/api/v1")
+
+
+# --- CJI pattern matching tests ---
+
+class TestCJIORI:
+    """Tests for the CJI: ORI Number pattern."""
+
+    def setup_method(self):
+        self.pattern = load_all_patterns()["CJI: ORI Number"]
+
+    def test_matches_california_ori(self):
+        assert self.pattern.search('ori = "CA0380000"')
+
+    def test_matches_texas_ori(self):
+        assert self.pattern.search("agency_id: TX0140000")
+
+    def test_matches_json_format(self):
+        assert self.pattern.search('"ori": "NY0300000"')
+
+    def test_rejects_invalid_state_code(self):
+        """XX is not a valid FIPS state code."""
+        assert not self.pattern.search('ori = "XX0380000"')
+
+    def test_rejects_no_assignment_context(self):
+        """Random alphanumeric strings shouldn't match without a keyword."""
+        assert not self.pattern.search("CA0380000")
+
+
+class TestCJINCIC:
+    """Tests for the CJI: NCIC Query Code pattern."""
+
+    def setup_method(self):
+        self.pattern = load_all_patterns()["CJI: NCIC Query Code"]
+
+    def test_matches_hot_file_query(self):
+        assert self.pattern.search("NCIC QH hot file query")
+
+    def test_matches_wanted_persons(self):
+        assert self.pattern.search("NCIC QW wanted persons check")
+
+    def test_rejects_without_ncic_keyword(self):
+        """QH alone is too generic — requires NCIC nearby."""
+        assert not self.pattern.search("QH query submitted")
+
+
+class TestCJIFBI:
+    """Tests for the CJI: FBI Number pattern."""
+
+    def setup_method(self):
+        self.pattern = load_all_patterns()["CJI: FBI Number"]
+
+    def test_matches_fbi_number(self):
+        assert self.pattern.search('fbi_number = "123456AA7"')
+
+    def test_matches_ucn(self):
+        assert self.pattern.search("ucn: 987654321")
+
+    def test_rejects_no_keyword(self):
+        assert not self.pattern.search("123456AA7")
+
+
+class TestCJISID:
+    """Tests for the CJI: State ID (SID) pattern."""
+
+    def setup_method(self):
+        self.pattern = load_all_patterns()["CJI: State ID (SID)"]
+
+    def test_matches_sid(self):
+        assert self.pattern.search('sid = "CA12345678"')
+
+    def test_matches_state_id(self):
+        assert self.pattern.search("state_id: NY98765432")
+
+    def test_rejects_no_keyword(self):
+        assert not self.pattern.search("CA12345678")
+
+
+# --- Custom pattern loading tests ---
+
+def test_custom_patterns_load(tmp_path):
+    """Custom patterns file should load and compile regex."""
+    patterns_file = tmp_path / "custom.json"
+    patterns_file.write_text('{"Test Pattern": "test_[0-9]+"}')
+
+    result = load_custom(str(patterns_file))
+    assert "Test Pattern" in result
+    assert result["Test Pattern"].search("test_123")
+
+
+def test_custom_patterns_invalid_json(tmp_path):
+    """Invalid JSON should cause SystemExit."""
+    patterns_file = tmp_path / "bad.json"
+    patterns_file.write_text("not json at all")
+
+    import pytest
+    with pytest.raises(SystemExit):
+        load_custom(str(patterns_file))
+
+
+def test_custom_patterns_invalid_regex(tmp_path):
+    """Invalid regex syntax should cause SystemExit."""
+    patterns_file = tmp_path / "bad_regex.json"
+    patterns_file.write_text('{"Bad": "[invalid"}')
+
+    import pytest
+    with pytest.raises(SystemExit):
+        load_custom(str(patterns_file))
+
+
+def test_custom_patterns_nonexistent_file():
+    """Nonexistent file should cause SystemExit."""
+    import pytest
+    with pytest.raises(SystemExit):
+        load_custom("/nonexistent/path/patterns.json")

--- a/tests/test_scanner.py
+++ b/tests/test_scanner.py
@@ -1,0 +1,219 @@
+"""Tests for the core scanning logic.
+
+Tests the scan() function from secret_scanner.scanner with various
+directory configurations. Uses pytest's tmp_path fixture to create
+isolated temporary directories for each test — this is dependency
+injection, where pytest sees tmp_path in the function signature and
+automatically provides a unique Path object.
+
+These tests verify the scanner handles edge cases gracefully:
+binary files, empty directories, permission errors, symlinks outside
+the scan root, and large files that exceed the size limit.
+"""
+
+import os
+
+from secret_scanner.patterns import load_all_patterns
+from secret_scanner.scanner import scan, MAX_FILE_SIZE
+
+
+def test_scan_finds_aws_key(tmp_path):
+    """Scanner should detect an AWS Access Key ID in a file."""
+    config = tmp_path / "config.json"
+    config.write_text('{"aws_access_key_id": "AKIAIOSFODNN7EXAMPLE"}')
+
+    patterns = load_all_patterns()
+    result = scan(tmp_path, patterns)
+
+    assert result["total_findings"] == 1
+    assert result["findings"][0]["finding_type"] == "AWS Access Key ID"
+    assert result["findings"][0]["severity"] == "CRITICAL"
+
+
+def test_scan_clean_file(tmp_path):
+    """Scanner should produce zero findings for a clean file."""
+    config = tmp_path / "clean.json"
+    config.write_text('{"app_name": "test", "debug": false}')
+
+    patterns = load_all_patterns()
+    result = scan(tmp_path, patterns)
+
+    assert result["total_findings"] == 0
+    assert result["total_files_scanned"] == 1
+
+
+def test_scan_empty_directory(tmp_path):
+    """Scanner should handle an empty directory without errors."""
+    patterns = load_all_patterns()
+    result = scan(tmp_path, patterns)
+
+    assert result["total_findings"] == 0
+    assert result["total_files_scanned"] == 0
+    assert result["skipped_files"] == 0
+
+
+def test_scan_binary_file_skipped(tmp_path):
+    """Binary files should be skipped, not crash the scanner."""
+    binary = tmp_path / "image.png"
+    binary.write_bytes(b"\x89PNG\r\n\x1a\n" + b"\xff" * 100)
+
+    patterns = load_all_patterns()
+    result = scan(tmp_path, patterns)
+
+    assert result["skipped_files"] == 1
+    assert result["total_findings"] == 0
+
+
+def test_scan_nested_directories(tmp_path):
+    """Scanner should recurse into subdirectories."""
+    nested = tmp_path / "level1" / "level2"
+    nested.mkdir(parents=True)
+
+    # Place files at two different depths so directories_scanned >= 2.
+    top_config = tmp_path / "top.json"
+    top_config.write_text('api_key = "top_level_key"')
+    deep_config = nested / "secret.json"
+    deep_config.write_text('password = "deep_secret"')
+
+    patterns = load_all_patterns()
+    result = scan(tmp_path, patterns)
+
+    assert result["total_findings"] >= 2
+    assert result["directories_scanned"] >= 2
+
+
+def test_scan_empty_file(tmp_path):
+    """Empty files should be scanned without errors or findings."""
+    empty = tmp_path / "empty.txt"
+    empty.write_text("")
+
+    patterns = load_all_patterns()
+    result = scan(tmp_path, patterns)
+
+    assert result["total_files_scanned"] == 1
+    assert result["total_findings"] == 0
+    assert result["skipped_files"] == 0
+
+
+def test_scan_file_no_trailing_newline(tmp_path):
+    """Files without a trailing newline should still be scanned."""
+    config = tmp_path / "config.env"
+    # write_text adds no trailing newline by default
+    config.write_text('password = "no_newline"')
+
+    patterns = load_all_patterns()
+    result = scan(tmp_path, patterns)
+
+    assert result["total_findings"] >= 1
+
+
+def test_scan_multiple_findings_per_file(tmp_path):
+    """A file with multiple secrets should produce multiple findings."""
+    config = tmp_path / "multi.conf"
+    config.write_text(
+        'aws_access_key_id = AKIAIOSFODNN7EXAMPLE\n'
+        'password = "hunter2"\n'
+        'api_key = "sk-live-abc123def456"\n'
+    )
+
+    patterns = load_all_patterns()
+    result = scan(tmp_path, patterns)
+
+    assert result["total_findings"] >= 3
+    assert result["files_with_findings"] == 1
+
+
+def test_scan_line_numbers_correct(tmp_path):
+    """Line numbers should be 1-indexed and accurate."""
+    config = tmp_path / "lines.conf"
+    config.write_text(
+        "# comment line 1\n"
+        "# comment line 2\n"
+        'password = "on_line_3"\n'
+    )
+
+    patterns = load_all_patterns()
+    result = scan(tmp_path, patterns)
+
+    assert result["findings"][0]["line_number"] == 3
+
+
+def test_scan_symlink_outside_directory_skipped(tmp_path):
+    """Symlinks pointing outside the scan root should be skipped."""
+    # Create a file outside the scan directory
+    import tempfile
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".txt", delete=False) as f:
+        f.write('password = "external_secret"')
+        external_path = f.name
+
+    try:
+        # Create a symlink inside tmp_path pointing to the external file
+        link = tmp_path / "external_link.txt"
+        link.symlink_to(external_path)
+
+        patterns = load_all_patterns()
+        result = scan(tmp_path, patterns)
+
+        # The symlink should be skipped, not scanned
+        assert result["skipped_files"] == 1
+        assert result["total_findings"] == 0
+    finally:
+        os.unlink(external_path)
+
+
+def test_scan_large_file_skipped(tmp_path):
+    """Files exceeding MAX_FILE_SIZE should be skipped."""
+    large = tmp_path / "huge.txt"
+    # Create a file just over the limit using seek (doesn't write actual data)
+    with open(large, "wb") as f:
+        f.seek(MAX_FILE_SIZE + 1)
+        f.write(b"\0")
+
+    patterns = load_all_patterns()
+    result = scan(tmp_path, patterns)
+
+    assert result["skipped_files"] == 1
+    assert result["total_findings"] == 0
+
+
+def test_scan_result_has_all_keys(tmp_path):
+    """Scan result dict should contain all expected keys."""
+    config = tmp_path / "test.txt"
+    config.write_text("clean content")
+
+    patterns = load_all_patterns()
+    result = scan(tmp_path, patterns)
+
+    expected_keys = {
+        "findings", "total_files_scanned", "total_findings",
+        "files_with_findings", "skipped_files", "directories_scanned",
+        "scan_duration", "affected_files",
+    }
+    assert set(result.keys()) == expected_keys
+
+
+def test_scan_affected_files_sorted(tmp_path):
+    """Affected files list should be sorted alphabetically."""
+    for name in ["c_config.txt", "a_config.txt", "b_config.txt"]:
+        (tmp_path / name).write_text('password = "test"')
+
+    patterns = load_all_patterns()
+    result = scan(tmp_path, patterns)
+
+    assert result["affected_files"] == sorted(result["affected_files"])
+
+
+def test_scan_finding_has_all_fields(tmp_path):
+    """Each finding dict should contain all required fields."""
+    config = tmp_path / "test.conf"
+    config.write_text("AKIAIOSFODNN7EXAMPLE")
+
+    patterns = load_all_patterns()
+    result = scan(tmp_path, patterns)
+
+    finding = result["findings"][0]
+    expected_fields = {
+        "file_path", "line_number", "finding_type",
+        "pattern_matched", "severity", "control_ids",
+    }
+    assert set(finding.keys()) == expected_fields


### PR DESCRIPTION
## Changes
- Add 95 unit tests across 4 test files covering patterns, scanner, output, and CLI
- test_patterns.py: 40 tests — positive/negative matching for all 13 patterns, pattern loading, control/severity mappings, custom pattern loading and error handling
- test_scanner.py: 14 tests — AWS key detection, clean files, empty dirs, binary skip, nested dirs, empty files, no trailing newline, multiple findings, line numbers, symlink escape, large file skip, result structure
- test_output.py: 8 tests — console alert/skip/summary formatting, severity breakdown, JSON report schema, overwrite warning
- test_cli.py: 14 tests — all argument parser flags and defaults, exit codes
- Add Makefile with make test, make scan, and make scan-json targets
- All 95 tests pass in 0.27s

## Controls Addressed
- SA-11: Developer Testing and Evaluation — the compliance tool is itself compliant with development best practices

## Testing
- make test runs full suite: 95 passed in 0.27s

Closes #13