### PR TITLE
feat: add pre-commit hook configuration

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,25 @@
+# Pre-commit framework hook definition for secret_scanner.
+#
+# This file tells the pre-commit framework how to run this scanner.
+# Users add this repo to their .pre-commit-config.yaml like:
+#
+#   repos:
+#     - repo: https://github.com/0xBahalaNa/secret-scanner
+#       rev: main
+#       hooks:
+#         - id: secret-scanner
+#
+# The pre-commit framework automatically passes only staged files to the
+# hook via the positional arguments, which we receive through --files.
+# This means only files being committed are scanned — not the entire repo.
+#
+# Controls addressed:
+#   CM-3: Configuration Change Control — prevents secrets from entering VCS
+#   SA-11: Developer Testing — automated testing at commit time
+
+- id: secret-scanner
+  name: Secret Scanner
+  description: Scan staged files for secrets, credentials, and CJI data
+  entry: python -m secret_scanner --files
+  language: python
+  types: [text]

--- a/Makefile
+++ b/Makefile
@@ -4,11 +4,12 @@
 # for indentation (not spaces) — this is a Makefile syntax requirement.
 #
 # Usage:
-#   make test    — run the full test suite with pytest
-#   make scan    — run the scanner against test_configs/
-#   make scan-json — run the scanner and output JSON results
+#   make test          — run the full test suite with pytest
+#   make scan          — run the scanner against test_configs/
+#   make scan-json     — run the scanner and output JSON results
+#   make install-hooks — install the standalone pre-commit hook
 
-.PHONY: test scan scan-json
+.PHONY: test scan scan-json install-hooks
 
 test:
 	python -m pytest tests/ -v
@@ -18,3 +19,8 @@ scan:
 
 scan-json:
 	python -m secret_scanner --output json
+
+install-hooks:
+	cp hooks/pre-commit .git/hooks/pre-commit
+	chmod +x .git/hooks/pre-commit
+	@echo "Pre-commit hook installed. Staged files will be scanned on commit."

--- a/README.md
+++ b/README.md
@@ -49,25 +49,25 @@ CJI patterns address CJIS Security Policy v6.0 requirements: CJI must never appe
 Scan the default `test_configs/` directory:
 
 ```bash
-python secret_scanner.py
+python -m secret_scanner
 ```
 
 Scan a specific directory:
 
 ```bash
-python secret_scanner.py /path/to/configs
+python -m secret_scanner /path/to/configs
 ```
 
 Run in informational mode (always exit 0, even if secrets are found):
 
 ```bash
-python secret_scanner.py /path/to/configs --exit-zero
+python -m secret_scanner /path/to/configs --exit-zero
 ```
 
 Load additional detection patterns from a JSON file:
 
 ```bash
-python secret_scanner.py /path/to/configs --patterns custom_patterns.json
+python -m secret_scanner /path/to/configs --patterns custom_patterns.json
 ```
 
 The patterns file should be a flat JSON object of `{"pattern_name": "regex_string"}`:
@@ -84,7 +84,7 @@ Custom patterns are merged with the built-in defaults. If a custom pattern has t
 Export findings as structured JSON for evidence pipelines:
 
 ```bash
-python secret_scanner.py /path/to/configs --output json
+python -m secret_scanner /path/to/configs --output json
 ```
 
 This writes `scan_results.json` with three sections:
@@ -97,7 +97,7 @@ See [`examples/sample_output.json`](examples/sample_output.json) for the full sc
 View all options:
 
 ```bash
-python secret_scanner.py --help
+python -m secret_scanner --help
 ```
 
 ## Exit Codes
@@ -108,6 +108,51 @@ python secret_scanner.py --help
 | `1`  | Secrets detected (default behavior) |
 
 In a CI/CD pipeline, the non-zero exit code will cause the step to fail, blocking merges that contain exposed secrets.
+
+## Pre-commit Integration
+
+The scanner can run as a pre-commit hook, catching secrets before they enter version control. This is the highest-value use case — a preventive control at the earliest CI/CD pipeline gate (CM-3: Configuration Change Control).
+
+### Option 1: Pre-commit Framework
+
+If your team uses the [pre-commit framework](https://pre-commit.com), add this to your `.pre-commit-config.yaml`:
+
+```yaml
+repos:
+  - repo: https://github.com/0xBahalaNa/secret-scanner
+    rev: main
+    hooks:
+      - id: secret-scanner
+```
+
+The framework automatically passes only staged files to the scanner.
+
+### Option 2: Standalone Git Hook
+
+For a dependency-free setup, install the bundled hook script:
+
+```bash
+make install-hooks
+```
+
+Or manually:
+
+```bash
+cp hooks/pre-commit .git/hooks/pre-commit
+chmod +x .git/hooks/pre-commit
+```
+
+The standalone hook uses `git diff --cached --name-only --diff-filter=ACM` to scan only staged files that are added, copied, or modified.
+
+### Scanning Specific Files
+
+Both hook options use the `--files` flag, which you can also use directly:
+
+```bash
+python -m secret_scanner --files config.json terraform.tf
+```
+
+This scans only the specified files instead of recursing a directory.
 
 ## Compliance Controls Addressed
 

--- a/hooks/pre-commit
+++ b/hooks/pre-commit
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# Standalone pre-commit hook for secret_scanner.
+#
+# This script runs the secret scanner against only the files staged for
+# commit (git add). It's an alternative to the pre-commit framework for
+# teams that want a simple, dependency-free git hook.
+#
+# Install with:
+#   cp hooks/pre-commit .git/hooks/pre-commit
+#   chmod +x .git/hooks/pre-commit
+#
+# Or use: make install-hooks
+#
+# How it works:
+#   1. git diff --cached --name-only gets the list of staged files
+#   2. --diff-filter=ACM limits to Added, Copied, or Modified files
+#      (deleted files would fail when the scanner tries to read them)
+#   3. The file list is passed to the scanner via --files
+#   4. If secrets are found, the commit is blocked (exit code 1)
+#
+# Controls addressed:
+#   CM-3: Configuration Change Control — prevents secrets from entering VCS
+#   SA-11: Developer Testing — automated testing at commit time
+
+# Get staged files that are text-based (added, copied, or modified).
+STAGED_FILES=$(git diff --cached --name-only --diff-filter=ACM)
+
+# If no files are staged, nothing to scan — allow the commit.
+if [ -z "$STAGED_FILES" ]; then
+    exit 0
+fi
+
+# Run the scanner against only the staged files.
+# shellcheck disable=SC2086
+python -m secret_scanner --files $STAGED_FILES

--- a/secret_scanner/cli.py
+++ b/secret_scanner/cli.py
@@ -7,8 +7,10 @@ scanner can be imported and used as a library without argparse being involved.
 
 Usage:
     python -m secret_scanner [directory] [--exit-zero] [--patterns FILE] [--output json] [--output-file PATH]
+    python -m secret_scanner --files FILE [FILE ...] [--exit-zero]
 
 If no directory is provided, defaults to test_configs/.
+Use --files to scan specific files (e.g., from a pre-commit hook).
 """
 
 import argparse
@@ -20,7 +22,7 @@ from .output.console import print_summary
 from .output.json_report import write_json_report
 from .patterns import load_all_patterns
 from .patterns.custom import load as load_custom_patterns
-from .scanner import scan
+from .scanner import scan, scan_files
 
 
 def build_parser():
@@ -81,6 +83,17 @@ def build_parser():
         help="Path for JSON output file (default: scan_results.json). Requires --output json.",
     )
 
+    # --files: scan specific files instead of a directory.
+    # Used by pre-commit hooks where only staged files should be scanned.
+    # nargs="+" means "one or more arguments" — at least one file is required.
+    # The pre-commit framework appends staged file paths after this flag.
+    parser.add_argument(
+        "--files",
+        nargs="+",
+        metavar="FILE",
+        help="Scan specific files instead of a directory (used by pre-commit hooks)",
+    )
+
     return parser
 
 
@@ -93,16 +106,6 @@ def main():
     """
     parser = build_parser()
     args = parser.parse_args()
-    folder = Path(args.directory)
-
-    # Validate that the path exists and is a directory before scanning.
-    if not folder.exists():
-        print(f"[ERROR] Path does not exist: {folder}")
-        sys.exit(1)
-
-    if not folder.is_dir():
-        print(f"[ERROR] Path is not a directory: {folder}")
-        sys.exit(1)
 
     # Build the pattern set: start with built-in, then merge custom.
     patterns = load_all_patterns()
@@ -112,11 +115,31 @@ def main():
         print(f"Loaded {len(custom)} custom pattern(s) from {args.patterns}")
         patterns.update(custom)
 
-    print(f"Scanning folder: {folder}")
-    print(f"Active patterns: {len(patterns)}")
+    # Two scan modes: --files for specific files (pre-commit hooks),
+    # or directory mode (default) for recursive scanning.
+    if args.files:
+        # File mode: scan only the specified files. Used by pre-commit
+        # hooks where only staged files should be scanned for performance.
+        print(f"Scanning {len(args.files)} file(s)")
+        print(f"Active patterns: {len(patterns)}")
+        result = scan_files(args.files, patterns)
+        scan_target = "staged files"
+    else:
+        # Directory mode: scan all files recursively.
+        folder = Path(args.directory)
 
-    # Run the scan — this is where the actual work happens.
-    result = scan(folder, patterns)
+        if not folder.exists():
+            print(f"[ERROR] Path does not exist: {folder}")
+            sys.exit(1)
+
+        if not folder.is_dir():
+            print(f"[ERROR] Path is not a directory: {folder}")
+            sys.exit(1)
+
+        print(f"Scanning folder: {folder}")
+        print(f"Active patterns: {len(patterns)}")
+        result = scan(folder, patterns)
+        scan_target = str(folder)
 
     # Print human-readable summary to console.
     print_summary(result)
@@ -127,7 +150,7 @@ def main():
             scan_result=result,
             output_file=args.output_file,
             scanner_version=__version__,
-            folder=folder,
+            folder=scan_target,
             patterns_active=len(patterns),
         )
 

--- a/secret_scanner/scanner.py
+++ b/secret_scanner/scanner.py
@@ -1,12 +1,15 @@
 """Core scanning logic for the secret scanner.
 
-This module contains the scan() function — the heart of the scanner. It
-takes a directory and a set of patterns, iterates through every file
-recursively, and returns structured results. The scan logic is separated
-from CLI parsing and output formatting so it can be:
+This module contains two scan functions:
+  - scan(directory, patterns) — recursively scans all files in a directory
+  - scan_files(file_paths, patterns) — scans a specific list of files
+
+The scan logic is separated from CLI parsing and output formatting so it
+can be:
   1. Called from the CLI (python -m secret_scanner)
-  2. Imported into other Python scripts (from secret_scanner.scanner import scan)
-  3. Tested in isolation (test_scanner.py)
+  2. Used as a pre-commit hook (python -m secret_scanner --files ...)
+  3. Imported into other Python scripts (from secret_scanner.scanner import scan)
+  4. Tested in isolation (test_scanner.py)
 
 This separation of concerns is the primary goal of the modular refactor.
 """
@@ -149,6 +152,112 @@ def scan(directory, patterns):
 
         if found_issue:
             files_with_issues.add(str(relative_path))
+
+    scan_duration = round(time.time() - scan_start, 3)
+
+    return {
+        "findings": findings,
+        "total_files_scanned": total_files_scanned,
+        "total_findings": len(findings),
+        "files_with_findings": len(files_with_issues),
+        "skipped_files": skipped_files,
+        "directories_scanned": len(directories_scanned),
+        "scan_duration": scan_duration,
+        "affected_files": sorted(files_with_issues),
+    }
+
+
+def scan_files(file_paths, patterns):
+    """Scan a specific list of files for secrets matching the given patterns.
+
+    This is the function used by pre-commit hooks, where only staged files
+    should be scanned — not the entire directory. It applies the same
+    pattern matching and error handling as scan(), but iterates over an
+    explicit list of file paths instead of recursing a directory.
+
+    No symlink escape check is performed here because the caller (the
+    pre-commit framework or the standalone hook script) controls which
+    files are passed. The file size and line length limits still apply.
+
+    Args:
+        file_paths: List of path strings to scan.
+        patterns: Dict of {name: compiled regex} patterns to match against.
+
+    Returns:
+        A dict with the same structure as scan() — findings, counts, etc.
+    """
+    findings = []
+    files_with_issues = set()
+    skipped_files = 0
+    directories_scanned = set()
+    total_files_scanned = 0
+
+    scan_start = time.time()
+
+    for file_path_str in file_paths:
+        item = Path(file_path_str)
+
+        if not item.is_file():
+            print_skip(file_path_str, "Not a file or does not exist.")
+            skipped_files += 1
+            continue
+
+        total_files_scanned += 1
+        directories_scanned.add(item.parent)
+
+        # File size check.
+        try:
+            file_size = item.stat().st_size
+        except OSError:
+            print_skip(file_path_str, "Could not read file metadata.")
+            skipped_files += 1
+            continue
+
+        if file_size > MAX_FILE_SIZE:
+            print_skip(
+                file_path_str,
+                f"File exceeds {MAX_FILE_SIZE // (1024 * 1024)}MB size limit."
+            )
+            skipped_files += 1
+            continue
+
+        found_issue = False
+
+        try:
+            with open(item, "r") as f:
+                for line_number, line in enumerate(f, start=1):
+                    if len(line) > MAX_LINE_LENGTH:
+                        continue
+
+                    for pattern_name, pattern_regex in patterns.items():
+                        if pattern_regex.search(line):
+                            severity = SEVERITY_MAP.get(pattern_name, "MEDIUM")
+                            print_alert(file_path_str, line_number, pattern_name, severity)
+                            found_issue = True
+
+                            findings.append({
+                                "file_path": file_path_str,
+                                "line_number": line_number,
+                                "finding_type": pattern_name,
+                                "pattern_matched": pattern_regex.pattern,
+                                "severity": severity,
+                                "control_ids": CONTROL_MAP.get(pattern_name, []),
+                            })
+
+        except UnicodeDecodeError:
+            print_skip(file_path_str, "The file type is not compatible.")
+            skipped_files += 1
+            continue
+        except PermissionError:
+            print_skip(
+                file_path_str,
+                "You do not have the necessary permissions for this file."
+            )
+            skipped_files += 1
+            continue
+
+        if found_issue:
+            files_with_issues.add(file_path_str)
 
     scan_duration = round(time.time() - scan_start, 3)
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -75,6 +75,20 @@ def test_parser_patterns_flag():
     assert args.patterns == "custom.json"
 
 
+def test_parser_files_flag():
+    """--files should accept one or more file paths."""
+    parser = build_parser()
+    args = parser.parse_args(["--files", "a.txt", "b.txt", "c.txt"])
+    assert args.files == ["a.txt", "b.txt", "c.txt"]
+
+
+def test_parser_files_default():
+    """files should default to None."""
+    parser = build_parser()
+    args = parser.parse_args([])
+    assert args.files is None
+
+
 def test_parser_all_flags_combined():
     """All flags should work together without conflict."""
     parser = build_parser()
@@ -142,3 +156,30 @@ def test_exit_code_1_on_nonexistent_directory():
     )
     assert result.returncode == 1
     assert "[ERROR]" in result.stderr or "[ERROR]" in result.stdout
+
+
+def test_files_flag_finds_secrets(tmp_path):
+    """--files should scan only the specified files and exit 1 on findings."""
+    import subprocess
+    config = tmp_path / "secret.txt"
+    config.write_text("AKIAIOSFODNN7EXAMPLE")
+
+    result = subprocess.run(
+        ["python", "-m", "secret_scanner", "--files", str(config)],
+        capture_output=True, text=True,
+    )
+    assert result.returncode == 1
+    assert "CRITICAL" in result.stdout
+
+
+def test_files_flag_clean_exit_0(tmp_path):
+    """--files with clean files should exit 0."""
+    import subprocess
+    config = tmp_path / "clean.txt"
+    config.write_text("nothing secret here")
+
+    result = subprocess.run(
+        ["python", "-m", "secret_scanner", "--files", str(config)],
+        capture_output=True, text=True,
+    )
+    assert result.returncode == 0

--- a/tests/test_scanner.py
+++ b/tests/test_scanner.py
@@ -14,7 +14,7 @@ the scan root, and large files that exceed the size limit.
 import os
 
 from secret_scanner.patterns import load_all_patterns
-from secret_scanner.scanner import scan, MAX_FILE_SIZE
+from secret_scanner.scanner import scan, scan_files, MAX_FILE_SIZE
 
 
 def test_scan_finds_aws_key(tmp_path):
@@ -217,3 +217,90 @@ def test_scan_finding_has_all_fields(tmp_path):
         "pattern_matched", "severity", "control_ids",
     }
     assert set(finding.keys()) == expected_fields
+
+
+# --- scan_files() tests ---
+
+def test_scan_files_finds_secret(tmp_path):
+    """scan_files should detect secrets in the specified files."""
+    config = tmp_path / "config.json"
+    config.write_text('{"aws_access_key_id": "AKIAIOSFODNN7EXAMPLE"}')
+
+    patterns = load_all_patterns()
+    result = scan_files([str(config)], patterns)
+
+    assert result["total_findings"] == 1
+    assert result["findings"][0]["finding_type"] == "AWS Access Key ID"
+
+
+def test_scan_files_clean_file(tmp_path):
+    """scan_files should produce zero findings for a clean file."""
+    config = tmp_path / "clean.json"
+    config.write_text('{"app_name": "test"}')
+
+    patterns = load_all_patterns()
+    result = scan_files([str(config)], patterns)
+
+    assert result["total_findings"] == 0
+    assert result["total_files_scanned"] == 1
+
+
+def test_scan_files_multiple_files(tmp_path):
+    """scan_files should scan all specified files."""
+    secret = tmp_path / "secret.txt"
+    secret.write_text("AKIAIOSFODNN7EXAMPLE")
+    clean = tmp_path / "clean.txt"
+    clean.write_text("nothing here")
+
+    patterns = load_all_patterns()
+    result = scan_files([str(secret), str(clean)], patterns)
+
+    assert result["total_files_scanned"] == 2
+    assert result["total_findings"] == 1
+    assert result["files_with_findings"] == 1
+
+
+def test_scan_files_nonexistent_skipped(tmp_path):
+    """scan_files should skip files that don't exist."""
+    patterns = load_all_patterns()
+    result = scan_files(["/nonexistent/file.txt"], patterns)
+
+    assert result["skipped_files"] == 1
+    assert result["total_files_scanned"] == 0
+
+
+def test_scan_files_binary_skipped(tmp_path):
+    """scan_files should skip binary files."""
+    binary = tmp_path / "image.png"
+    binary.write_bytes(b"\x89PNG\r\n\x1a\n" + b"\xff" * 100)
+
+    patterns = load_all_patterns()
+    result = scan_files([str(binary)], patterns)
+
+    assert result["skipped_files"] == 1
+    assert result["total_findings"] == 0
+
+
+def test_scan_files_empty_list():
+    """scan_files with an empty list should return zero counts."""
+    patterns = load_all_patterns()
+    result = scan_files([], patterns)
+
+    assert result["total_files_scanned"] == 0
+    assert result["total_findings"] == 0
+
+
+def test_scan_files_result_has_all_keys(tmp_path):
+    """scan_files result should have the same structure as scan()."""
+    config = tmp_path / "test.txt"
+    config.write_text("clean content")
+
+    patterns = load_all_patterns()
+    result = scan_files([str(config)], patterns)
+
+    expected_keys = {
+        "findings", "total_files_scanned", "total_findings",
+        "files_with_findings", "skipped_files", "directories_scanned",
+        "scan_duration", "affected_files",
+    }
+    assert set(result.keys()) == expected_keys


### PR DESCRIPTION
## Changes
- Add scan_files() function for scanning specific files instead of directories
- Add --files CLI flag for pre-commit hook integration
- Add .pre-commit-hooks.yaml for the pre-commit framework
- Add hooks/pre-commit standalone git hook script
- Add make install-hooks Makefile target
- Add Pre-commit Integration section to README
- Update README usage examples from python secret_scanner.py to python -m secret_scanner
- Add 11 new tests (106 total, all passing)

## Controls Addressed
- CM-3: Configuration Change Control — prevents secrets from entering version control
- SA-11: Developer Testing and Evaluation — automated testing at commit time

## Testing
- Verified --files flag scans only specified files (exit 1 on secrets, exit 0 on clean)
- Verified pre-commit framework config defines correct entry point
- Verified standalone hook script is executable and uses git diff --cached
- All 106 tests pass in 0.41s

Closes #14