### PR TITLE
docs: add README badges for portfolio visual coherence

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
+![License](https://img.shields.io/badge/License-MIT-green?style=flat)
+![Python](https://img.shields.io/badge/Python-3.11%2B-3776ab?style=flat)
+![NIST 800-53](https://img.shields.io/badge/NIST-800--53%20Rev%205-004990?style=flat)
+![FedRAMP](https://img.shields.io/badge/FedRAMP-High%20Baseline-0071bc?style=flat)
+![CJIS](https://img.shields.io/badge/CJIS-Security%20Policy%20v6.0-cc0000?style=flat)
+
 # Secret Scanner
 
 A Python tool that scans directories for sensitive content using compiled regex patterns. Detects AWS credentials, API keys, passwords, private keys, JWTs, connection strings, and CJIS Criminal Justice Information (CJI) leakage. Designed for use in CI/CD pipelines and GRC engineering workflows targeting public safety technology environments.


### PR DESCRIPTION
Closes #38

## Changes
- Adds the standardized 5-badge block to the top of `README.md` (License, Python 3.11+, NIST 800-53 Rev 5, FedRAMP High Baseline, CJIS Security Policy v6.0)
- Matches the portfolio house style used in `aws-compliance-as-code`, `aws-config-compliance-monitor`, and `aws-grc-terraform-modules`
- No body content changed below the badge block
- AWS badge intentionally omitted — `secret-scanner` is a local-filesystem regex scanner, not an AWS-API auditor

## Controls Addressed
- No new control coverage — this is a documentation-only change that surfaces the existing control mappings (IA-5(7), SC-12, SC-13, SC-28) more visibly at the top of the README

## Testing
- [ ] Open the README on GitHub after merge and confirm all five badges render in order
- [ ] Confirm the H1 and Features sections still appear unchanged below the badges