### PR TITLE
docs: add Architecture Overview Mermaid diagram

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,27 @@ Maps to NIST 800-53 Rev 5 controls: **IA-5(7)**, **SC-12**, **SC-28**.
 Maps to FedRAMP High baseline controls: **IA-5(7)**, **SC-12**, **SC-28**.
 Maps to CJIS v6.0 controls: **SC-12**, **SC-13**, **SC-28**.
 
+## Architecture Overview
+
+```mermaid
+flowchart TD
+    CLI["python -m secret_scanner<br/>CLI entry"] --> WALK["Walk target directory"]
+    WALK --> PAT["Compiled regex patterns<br/>secrets + CJI"]
+    PAT --> OPT["Optional --patterns<br/>org-specific rules"]
+    PAT --> FIND["Findings<br/>file:line"]
+    OPT --> FIND
+    FIND --> CON["Console summary<br/>alerts · files · skipped"]
+    FIND --> JSON["Optional JSON export<br/>scan_results.json"]
+    FIND --> EXIT["CI exit code<br/>non-zero on secrets"]
+    CON --> HUM["Operators / reviewers"]
+    JSON --> PIPE["Evidence pipelines<br/>GRC / CI artifacts"]
+    EXIT --> CI["CI/CD gate"]
+```
+
+Editable Mermaid source (kept in sync with the fence above): [`docs/architecture.mmd`](docs/architecture.mmd).
+
+`python -m secret_scanner` walks a target directory, runs compiled secret and CJI regex patterns (optional `--patterns` for org rules), and reports `file:line` findings. Operators get a console summary; optional JSON export feeds evidence pipelines; a non-zero exit code gates CI unless `--exit-zero` is set.
+
 ## Features
 
 - Recursively scans all files in a target directory and its subdirectories

--- a/docs/architecture.mmd
+++ b/docs/architecture.mmd
@@ -1,0 +1,15 @@
+%% Editable Mermaid source for the README "Architecture Overview" section.
+%% Keep this file in sync with the inline ```mermaid fence in README.md.
+%% Diff-able source of truth for the architecture graph (no separate PNG export).
+flowchart TD
+    CLI["python -m secret_scanner<br/>CLI entry"] --> WALK["Walk target directory"]
+    WALK --> PAT["Compiled regex patterns<br/>secrets + CJI"]
+    PAT --> OPT["Optional --patterns<br/>org-specific rules"]
+    PAT --> FIND["Findings<br/>file:line"]
+    OPT --> FIND
+    FIND --> CON["Console summary<br/>alerts · files · skipped"]
+    FIND --> JSON["Optional JSON export<br/>scan_results.json"]
+    FIND --> EXIT["CI exit code<br/>non-zero on secrets"]
+    CON --> HUM["Operators / reviewers"]
+    JSON --> PIPE["Evidence pipelines<br/>GRC / CI artifacts"]
+    EXIT --> CI["CI/CD gate"]


### PR DESCRIPTION
## Summary
- Add an **Architecture Overview** section to the README: a Mermaid flowchart of the scan data flow — `python -m secret_scanner` → directory walk → compiled secret + CJI regex patterns (optional `--patterns` org rules) → `file:line` findings → console summary for operators, optional JSON export (`scan_results.json`) into evidence pipelines, and a non-zero exit code gating CI (`--exit-zero` opt-out)
- Add `docs/architecture.mmd` — diff-able, editable Mermaid source kept byte-identical with the README fence (diagram-as-code; no PNG export to go stale)

Documentation-only: no scanner or control logic changed.

## Test Plan
- [x] README fence and `docs/architecture.mmd` graph bodies verified byte-identical
- [x] Every diagram node verified against `secret_scanner/cli.py` (`--patterns`, `--output json` / `scan_results.json`, `--exit-zero` exit-code gate)
- [ ] Mermaid fence renders correctly on GitHub